### PR TITLE
syntax tweaks

### DIFF
--- a/syntax/dosini.vim
+++ b/syntax/dosini.vim
@@ -22,10 +22,11 @@ endif
 " shut case off
 syn case ignore
 
-syn match  dosiniNumber   "\<\d\+\>"
-syn match  dosiniNumber   "\<\d*\.\d\+\>"
-syn match  dosiniNumber   "\<\d\+e[+-]\=\d\+\>"
-syn match  dosiniLabel    "^.\{-}="
+syn match  dosiniLabel    "^.\{-}\ze\s*=" nextgroup=dosiniNumber,dosiniValue
+syn match  dosiniValue    "=\zs.*"
+syn match  dosiniNumber   "=\zs\s*\d\+\s*$"
+syn match  dosiniNumber   "=\zs\s*\d*\.\d\+\s*$"
+syn match  dosiniNumber   "=\zs\s*\d\+e[+-]\=\d\+\s*$"
 syn region dosiniHeader   start="^\s*\[" end="\]"
 syn match  dosiniComment  "^[#;].*$"
 


### PR DESCRIPTION
- highlight values as numbers only if they encompass the whole value (avoids odd highlighting with values like dash-123-delimited-678-hash) 
- don't highlight the equal signs or trailing whitespace as part of the label