### PR TITLE
Remove HiLink commands

### DIFF
--- a/syntax/dosini.vim
+++ b/syntax/dosini.vim
@@ -34,6 +34,7 @@ hi def link dosiniNumber   Number
 hi def link dosiniHeader   Special
 hi def link dosiniComment  Comment
 hi def link dosiniLabel    Type
+hi def link dosiniValue    String
 
 
 let b:current_syntax = "dosini"

--- a/syntax/dosini.vim
+++ b/syntax/dosini.vim
@@ -8,14 +8,11 @@
 " Repository:
 "     Mercurial:          https://bitbucket.org/xuhdev/syntax-dosini.vim
 "     Git:                https://github.com/xuhdev/syntax-dosini.vim
-" Last Change:            2011 Nov 8
+" Last Change:            2018 Sep 11
 
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
   finish
 endif
 
@@ -31,23 +28,13 @@ syn region dosiniHeader   start="^\s*\[" end="\]"
 syn match  dosiniComment  "^[#;].*$"
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_dosini_syntax_inits")
-  if version < 508
-    let did_dosini_syntax_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
+" Only when an item doesn't have highlighting yet
 
-  HiLink dosiniNumber   Number
-  HiLink dosiniHeader   Special
-  HiLink dosiniComment  Comment
-  HiLink dosiniLabel    Type
+hi def link dosiniNumber   Number
+hi def link dosiniHeader   Special
+hi def link dosiniComment  Comment
+hi def link dosiniLabel    Type
 
-  delcommand HiLink
-endif
 
 let b:current_syntax = "dosini"
 


### PR DESCRIPTION
Do as vim/vim and neovim/neovim do since vim/vim@f37506f60f and neovim/neovim@86b596dc7a
Depends on #3 